### PR TITLE
Change notification processor and fix for missing product image

### DIFF
--- a/src/common/Core/Extensions/CommerceContentExtensions.cs
+++ b/src/common/Core/Extensions/CommerceContentExtensions.cs
@@ -86,7 +86,14 @@ namespace OxxCommerceStarterKit.Core.Extensions
 
         public static CommerceMedia GetCommerceMedia(this EntryContentBase entry, int index)
         {
-            return entry.CommerceMediaCollection.OrderBy(m => m.SortOrder).Skip(index).FirstOrDefault();
+            if(entry.CommerceMediaCollection.Any())
+            {
+                return entry.CommerceMediaCollection.OrderBy(m => m.SortOrder).Skip(index).FirstOrDefault();
+            }
+            else
+            {
+                return null;
+            }
         }
 
 

--- a/src/web/Business/FindCatalogIndexingChangeNotificationProcessor.cs
+++ b/src/web/Business/FindCatalogIndexingChangeNotificationProcessor.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using EPiServer.Events.ChangeNotification;
 using EPiServer.Logging;
 using Mediachase.Commerce.Catalog;
-using Mediachase.Commerce.Core;
-using Mediachase.Commerce.Core.Dto;
-using Mediachase.Search;
 
-namespace OxxCommerceStarterKit.Web.Business.Initialization
+namespace OxxCommerceStarterKit.Web.Business
 {
     public class FindCatalogIndexingChangeNotificationProcessor : IChangeProcessor<string>
     {
@@ -47,9 +43,7 @@ namespace OxxCommerceStarterKit.Web.Business.Initialization
         private static readonly Guid _processorId = new Guid("ea403de2-c91d-4675-a82e-ac087ea368de");
         private static readonly IChangeListener _changeListener = new CatalogEntryChangeListener();
         private static readonly TimeSpan _retryInterval = TimeSpan.FromSeconds(30);
-        private static readonly int _maxBatchSize = 2;
-
-
+        private static readonly int _maxBatchSize = 5;
 
         public static Guid ProcessorId
         {

--- a/src/web/Business/Initialization/FindCatalogIndexingChangeNotificationInitialization.cs
+++ b/src/web/Business/Initialization/FindCatalogIndexingChangeNotificationInitialization.cs
@@ -1,0 +1,51 @@
+﻿/*
+Commerce Starter Kit for EPiServer
+
+All rights reserved. See LICENSE.txt in project root.
+
+Copyright (C) 2013-2014 Oxx AS
+Copyright (C) 2013-2014 BV Network AS
+
+*/
+
+using System.Linq;
+using EPiServer.Events.ChangeNotification;
+using EPiServer.Framework;
+using EPiServer.Framework.Initialization;
+using EPiServer.Logging;
+using EPiServer.ServiceLocation;
+
+namespace OxxCommerceStarterKit.Web.Business.Initialization
+{
+    [ModuleDependency(typeof(EPiServer.Commerce.Initialization.InitializationModule))]
+    public class FindCatalogIndexingChangeNotificationInitialization : IConfigurableModule
+    {
+        private ILogger _log = LogManager.GetLogger();
+
+        public void Initialize(InitializationEngine context)
+        {
+            _log.Debug("Try start recovery.");
+            var changeManager = ServiceLocator.Current.GetInstance<IChangeNotificationManager>();
+            var processor = changeManager.GetProcessorInfo().SingleOrDefault(ep => ep.ProcessorId == FindCatalogIndexingChangeNotificationProcessor.ProcessorId);
+            if (processor != null)
+            {
+                processor.TryStartRecovery();
+            }
+        }
+
+        public void Preload(string[] parameters)
+        {
+        }
+
+        public void Uninitialize(InitializationEngine context)
+        {
+        }
+
+        public void ConfigureContainer(ServiceConfigurationContext context)
+        {
+            _log.Debug("Registering FindCatalogIndexingChangeNotificationProcessor");
+            context.Container.Configure(c => c.For<IChangeProcessor>().Singleton().Add<FindCatalogIndexingChangeNotificationProcessor>());
+
+        }
+    }
+}

--- a/src/web/Business/Initialization/Initialization.cs
+++ b/src/web/Business/Initialization/Initialization.cs
@@ -160,7 +160,6 @@ namespace OxxCommerceStarterKit.Web.Business.Initialization
             context.Container.Configure(c => c.For<IHttpContextProvider>().Singleton().Use<HttpContextProvider>());
             context.Container.Configure(c => c.For<IPostNordClient>().Singleton().Use<PostNordClient>());
             context.Container.Configure(c => c.For<IStockUpdater>().Use<StockUpdater>());
-            context.Container.Configure(c => c.For<IChangeProcessor>().Singleton().Add<FindCatalogIndexingChangeNotificationProcessor>());
         }
     }
 }

--- a/src/web/CommerceStarterKit.Web.csproj
+++ b/src/web/CommerceStarterKit.Web.csproj
@@ -1066,12 +1066,13 @@
     <Compile Include="Business\Delivery\DeliveryLocation.cs" />
     <Compile Include="Business\Initialization\CatalogEventListener.cs" />
     <Compile Include="Business\Initialization\CommerceCachePrimer.cs" />
-    <Compile Include="Business\Initialization\FindCatalogIndexingChangeNotificationProcessor.cs" />
+    <Compile Include="Business\FindCatalogIndexingChangeNotificationProcessor.cs" />
     <Compile Include="Business\Initialization\CustomizedRenderingInitialization.cs" />
     <Compile Include="Business\Initialization\CustomModelMetadataProvider.cs" />
     <Compile Include="Business\Initialization\DependencyResolverInitialization.cs" />
     <Compile Include="Business\Initialization\DisplayModesInitialization.cs" />
     <Compile Include="Business\Initialization\IndexingEventInitialization.cs" />
+    <Compile Include="Business\Initialization\FindCatalogIndexingChangeNotificationInitialization.cs" />
     <Compile Include="Business\Initialization\MetadataInitialization.cs" />
     <Compile Include="Business\Initialization\SearchFieldInitialization.cs" />
     <Compile Include="Business\ISiteSettingsProvider.cs" />

--- a/src/web/Models/PageTypes/ArticlePage.cs
+++ b/src/web/Models/PageTypes/ArticlePage.cs
@@ -33,7 +33,7 @@ namespace OxxCommerceStarterKit.Web.Models.PageTypes
 		[Display(
 			Name = "List view image",
 			GroupName = SystemTabNames.Content,
-			Order = 1)]
+			Order = 11)]
 		[UIHint(UIHint.Image)]
 		public virtual Url ListViewImage { get; set; }
 

--- a/src/web/Models/ViewModels/CartItemModel.cs
+++ b/src/web/Models/ViewModels/CartItemModel.cs
@@ -43,9 +43,9 @@ namespace OxxCommerceStarterKit.Web.Models.ViewModels
 		    {
 		        ImageUrl = _urlResolver.Service.GetUrl(media.AssetContentLink(_permanentLinkMapper.Service));
 		    }
-            //If variant does not have images, we get image from product
-		    else
+            else if (parent != null)
 		    {
+                //If variant does not have images, we get image from product
                 media = parent.GetCommerceMedia();
                 if(media != null)
                     ImageUrl = _urlResolver.Service.GetUrl(media.AssetContentLink(_permanentLinkMapper.Service));


### PR DESCRIPTION
The change processor is not done yet, but should give us trouble. The YSOD for missing product images for a Wine variation is now fixed. Required you to go to all properties view in order to edit a wine product unless you added an image immediately.