### PR TITLE
Use name, not magic ID, for DIBS metaclass init

### DIFF
--- a/src/web/Business/Initialization/MetadataInitialization.cs
+++ b/src/web/Business/Initialization/MetadataInitialization.cs
@@ -82,8 +82,7 @@ namespace OxxCommerceStarterKit.Web.Business.Initialization
             string text1 = name;
             string text2 = name;
             string text3 = "Imported";
-            int num = 26; //TODO: Get Payment Class Id
-            MetaClass parentMetaClass = MetaClass.Load(mdContext, num);
+            MetaClass parentMetaClass = MetaClass.Load(mdContext, "OrderFormPayment");
 
             MetaClass metaClass = MetaClass.Load(mdContext, name);
 


### PR DESCRIPTION
The DIBS payment metaclass is initializated in `MetadataIntialization.cs`. The parent for this metaclass is fetched based on a hardcoded ID. The ID for the parent (the "Order Form Payment" class) may vary across environments. Hence, the DIBS payment metaclass is always created, but possibly under the wrong parent. 

I think this commits fixes this, by fetching the parent by name instead of ID. 